### PR TITLE
Use `msru` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "msru"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a014208ef068fd9eed02eceb063ecba151d9922de4f8b4bb3703ff3d2a3eaa"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +199,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "colored",
+ "msru",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 clap = { version = "4.5.9", features = ["derive"] }
 colored = "2.1.0"
+msru = "0.2.0"
 
 [build-dependencies]
 clap = { version = "4.5.9", features = ["cargo", "derive"] }


### PR DESCRIPTION
Converts the `ok` command code to use `msru` instead of manually calling `rdmsr`

Fixes: #4