### PR TITLE
Add more `ok` checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "libc"
+version = "0.2.155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
 name = "msru"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +205,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "colored",
+ "libc",
  "msru",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 clap = { version = "4.5.9", features = ["derive"] }
 colored = "2.1.0"
+libc = "0.2.155"
 msru = "0.2.0"
 
 [build-dependencies]

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -265,6 +265,24 @@ pub fn check_bios_sgx_reg_server() {
     }
 }
 
+pub fn check_cpu_manufacturer_id() {
+    let res = unsafe { std::arch::x86_64::__cpuid(0x0000_0000) };
+    let name: [u8; 12] = unsafe { std::mem::transmute([res.ebx, res.edx, res.ecx]) };
+    let name = String::from_utf8(name.to_vec()).unwrap();
+
+    report_results(
+        if name == "GenuineIntel" {
+            TestResult::Ok
+        } else {
+            TestResult::Failed
+        },
+        "Check CPUID 0x0 Manufacturer ID = GenuineIntel (required)",
+        "The CPUID Manufacturer ID should be GenuineIntel",
+        TestOptionalState::Required,
+        None,
+    );
+}
+
 fn report_results(
     result: TestResult,
     action: &str,
@@ -318,6 +336,7 @@ pub fn run_all_checks() {
     check_bios_tdx_key_split();
     check_bios_enabling_sgx();
     check_bios_sgx_reg_server();
+    check_cpu_manufacturer_id();
 
     println!();
     println!("Optional Features & Settings");
@@ -384,5 +403,10 @@ mod tests {
     #[test]
     fn test_check_tdx_module() {
         check_tdx_module();
+    }
+
+    #[test]
+    fn test_check_cpu_manufacturer_id() {
+        check_cpu_manufacturer_id();
     }
 }


### PR DESCRIPTION
Adds more checks to be done by the `ok` command:

- Ensure the CPU manufacturer ID = "GenuineIntel"
- Make sure KVM is supported
- Make sure that `/sys/module/kvm_intel/parameters/{sgx, tdx}` are enabled