### PR TITLE
Use a tree-like structure for running `ok` checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "clap"
 version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,7 @@ dependencies = [
 name = "tdxhost"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "clap_complete",
  "clap_mangen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.86"
 clap = { version = "4.5.9", features = ["derive"] }
 colored = "2.1.0"
 libc = "0.2.155"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,16 @@ mod ok;
 
 use clap::Parser;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let args = cli::Cli::parse();
 
-    match args.cmd {
+    let res = match args.cmd {
         cli::TdxCommand::Ok => ok::run_all_checks(),
+    };
+
+    if let Err(ref e) = res {
+        eprintln!("Error: {}", e);
     }
+
+    res
 }

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -1,40 +1,65 @@
+use anyhow::{anyhow, Result};
+use colored::Colorize;
 use msru::{Accessor, Msr};
 use std::process::Command;
 
-enum TestResult {
+#[derive(Debug, Default)]
+enum TestState {
     Ok,
+    #[default]
     Failed,
     #[allow(dead_code)]
     Warning,
     Tbd,
+    Skip,
 }
 
+impl From<&TestState> for String {
+    fn from(res: &TestState) -> Self {
+        match res {
+            TestState::Ok => "OK".to_string(),
+            TestState::Failed => "FAILED".to_string(),
+            TestState::Warning => "WARNING".to_string(),
+            TestState::Tbd => "TBD".to_string(),
+            TestState::Skip => "SKIP".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+enum TestOptionalState {
+    #[default]
+    Required,
+    Optional,
+}
+
+#[derive(Debug, Default)]
+enum TestOperationState {
+    Manual,
+    #[default]
+    Program,
+}
+
+#[derive(Debug)]
 pub enum KvmParameter {
     Tdx,
     Sgx,
 }
 
-impl From<&TestResult> for String {
-    fn from(res: &TestResult) -> Self {
-        match res {
-            TestResult::Ok => "OK".to_string(),
-            TestResult::Failed => "FAILED".to_string(),
-            TestResult::Warning => "WARNING".to_string(),
-            TestResult::Tbd => "TBD".to_string(),
-        }
-    }
+#[derive(Debug, Default)]
+struct TestResult {
+    action: String,
+    reason: String,
+    state: TestState,
+    optional_state: TestOptionalState,
+    operation: TestOperationState,
 }
 
-enum TestOptionalState {
-    Required,
-    Optional,
-}
-
-#[derive(Default)]
-enum TestOperation {
-    Manual,
-    #[default]
-    Program,
+struct Test {
+    name: &'static str,
+    run: Box<dyn Fn() -> TestResult>,
+    sub_tests: Vec<Test>,
+    post_run: Option<Box<dyn Fn()>>,
 }
 
 const SUPPORTED_OSES: [&str; 3] = [
@@ -57,7 +82,7 @@ fn get_os_pretty_name() -> String {
         .to_owned()
 }
 
-pub fn check_os() {
+pub fn check_os() -> bool {
     // get os name
     let pretty_name = get_os_pretty_name();
 
@@ -67,29 +92,10 @@ pub fn check_os() {
         .into_iter()
         .for_each(|o| supported = o == pretty_name);
 
-    // report the result
-    report_results(
-        if supported {
-            TestResult::Ok
-        } else {
-            TestResult::Failed
-        },
-        "Check OS: The distro and version are correct (required)",
-        "Your OS distro is not supported yet.",
-        TestOptionalState::Required,
-        None,
-    );
-
-    // print os information
-    println!("\tYour current OS is: {}", pretty_name);
-    println!("\tThe following OSs are supported:");
-    for os in SUPPORTED_OSES {
-        println!("\t\t{}", os);
-    }
-    println!("\tThere is no guarantee to other OS distros");
+    supported
 }
 
-pub fn check_tdx_module() {
+pub fn check_tdx_module() -> bool {
     let dmesg_output = Command::new("sudo")
         .arg("dmesg")
         .output()
@@ -98,227 +104,43 @@ pub fn check_tdx_module() {
     let dmesg_output = String::from_utf8(dmesg_output.stdout)
         .expect("unable to convert utf8 bytes to owned String");
 
-    if dmesg_output.contains("virt/tdx: module initialized") {
-        report_results(
-            TestResult::Ok,
-            "Check TDX Module: The module is initialized (required)",
-            "",
-            TestOptionalState::Required,
-            None,
-        );
-    } else {
-        report_results(
-            TestResult::Failed,
-            "Check TDX Module: The module is initialized (required)",
-            "TDX Module is required",
-            TestOptionalState::Required,
-            None,
-        );
-    }
+    dmesg_output.contains("virt/tdx: module initialized")
 }
 
-pub fn check_bios_memory_map() {
-    report_results(
-        TestResult::Tbd,
-        "Check BIOS: Volatile Memory should be 1LM (optional & manually)",
-        "",
-        TestOptionalState::Optional,
-        Some(TestOperation::Manual),
-    );
-
-    println!("\tPlease check your BIOS settings:");
-    println!("\t\tSocket Configuration -> Memory Configuration -> Memory Map");
-    println!("\t\t\tVolatile Memory (or Volatile Memory Mode) should be 1LM");
-    println!("\t\tA different BIOS might have a different path for this setting.");
-    println!("\t\tPlease skip this setting if it doesn't exist in your BIOS menu.");
-}
-
-pub fn check_bios_enabling_mktme() {
+pub fn check_bios_tme_bypass() -> bool {
     let msr_value = Msr::new(0x982, 0).unwrap().read().unwrap();
-
-    report_results(
-        if msr_value & (1 << 1) > 0 {
-            TestResult::Ok
-        } else {
-            TestResult::Failed
-        },
-        "Check BIOS: TME = Enabled (required)",
-        "The bit 1 of MSR 0x982 should be 1",
-        TestOptionalState::Required,
-        None,
-    );
+    msr_value & (1 << 31) > 0
 }
 
-pub fn check_bios_tme_bypass() {
-    let msr_value = Msr::new(0x982, 0).unwrap().read().unwrap();
-
-    let tme_bypass_enabled = msr_value & (1 << 31) > 0;
-    report_results(
-        if tme_bypass_enabled {
-            TestResult::Ok
-        } else {
-            TestResult::Failed
-        },
-        "Check BIOS: TME Bypass = Enabled (optional)",
-        "The bit 31 of MSR 0x982 should be 1",
-        TestOptionalState::Optional,
-        None,
-    );
-
-    if !tme_bypass_enabled {
-        println!("\tThe TME Bypass has not been enabled now.");
-    }
-
-    println!("\tIt's better to enable TME Bypass for traditional non-confidential workloads.");
-}
-
-pub fn check_bios_tme_mt() {
-    let msr_value = Msr::new(0x982, 0).unwrap().read().unwrap();
-
-    report_results(
-        if msr_value & (1 << 1) > 0 {
-            TestResult::Ok
-        } else {
-            TestResult::Failed
-        },
-        "Check BIOS: TME-MT/TME-MK (required & manually)",
-        "The bit 1 of MSR 0x982 should be 1",
-        TestOptionalState::Required,
-        None,
-    );
-
-    println!("\tPlease check your BIOS settings:");
-    println!("\t\tSocket Configuration -> Processor Configuration -> TME, TME-MT, TDX");
-    println!("\t\t\tTotal Memory Encryption Multi-Tenant (TME-MT) should be Enable");
-    println!("\t\tA different BIOS might have a different path for this setting.");
-}
-
-pub fn check_bios_enabling_tdx() {
-    let msr_value = Msr::new(0x1401, 0).unwrap().read().unwrap();
-
-    report_results(
-        if msr_value & (1 << 11) > 0 {
-            TestResult::Ok
-        } else {
-            TestResult::Failed
-        },
-        "Check BIOS: TDX = Enabled (required)",
-        "The bit 11 of MSR 0x1401 should be 1",
-        TestOptionalState::Required,
-        None,
-    );
-}
-
-pub fn check_bios_seam_loader() {
-    report_results(
-        TestResult::Tbd,
-        "Check BIOS: SEAM Loader = Enabled (optional)",
-        "",
-        TestOptionalState::Optional,
-        Some(TestOperation::Manual),
-    );
-}
-
-pub fn check_bios_tdx_key_split() {
-    let msr_value = Msr::new(0x981, 0).unwrap().read().unwrap();
-
-    report_results(
-        // check bits 50:36
-        if msr_value & (0x7fff << 36) != 0 {
-            TestResult::Ok
-        } else {
-            TestResult::Failed
-        },
-        "Check BIOS: TDX Key Split != 0 (required)",
-        "TDX Key Split should be non-zero",
-        TestOptionalState::Required,
-        None,
-    );
-}
-
-pub fn check_bios_enabling_sgx() {
-    let msr_value = Msr::new(0x3a, 0).unwrap().read().unwrap();
-
-    report_results(
-        if msr_value & (1 << 18) > 0 {
-            TestResult::Ok
-        } else {
-            TestResult::Failed
-        },
-        "Check BIOS: SGX = Enabled (required)",
-        "The bit 18 of MSR 0x3a should be 1",
-        TestOptionalState::Required,
-        None,
-    );
-}
-
-pub fn check_bios_sgx_reg_server() {
-    let msr_value = Msr::new(0xce, 0).unwrap().read().unwrap();
-
-    report_results(
-        TestResult::Tbd,
-        "Check BIOS: SGX registration server (required & manually)",
-        "",
-        TestOptionalState::Required,
-        Some(TestOperation::Manual),
-    );
-
-    if msr_value & (1 << 27) > 0 {
-        println!("\tSGX registration server is SBX");
-    } else {
-        println!("\tSGX registration server is LIV");
-    }
-}
-
-pub fn check_cpu_manufacturer_id() {
+pub fn check_cpu_manufacturer_id() -> String {
     let res = unsafe { std::arch::x86_64::__cpuid(0x0000_0000) };
     let name: [u8; 12] = unsafe { std::mem::transmute([res.ebx, res.edx, res.ecx]) };
-    let name = String::from_utf8(name.to_vec()).unwrap();
-
-    report_results(
-        if name == "GenuineIntel" {
-            TestResult::Ok
-        } else {
-            TestResult::Failed
-        },
-        "Check CPUID 0x0 Manufacturer ID = GenuineIntel (required)",
-        "The CPUID Manufacturer ID should be GenuineIntel",
-        TestOptionalState::Required,
-        None,
-    );
+    String::from_utf8(name.to_vec()).unwrap()
 }
 
-pub fn check_kvm_supported() {
+pub fn check_kvm_supported() -> (TestState, String) {
     use std::os::fd::AsRawFd;
 
-    let (result, reason) = match std::fs::File::open("/dev/kvm") {
+    match std::fs::File::open("/dev/kvm") {
         Ok(fd) => {
             let api_version = unsafe { libc::ioctl(fd.as_raw_fd(), 0xAE00, 0) };
             if api_version < 0 {
                 (
-                    TestResult::Failed,
-                    "KVM device node (/dev/kvm) should be accessible",
+                    TestState::Failed,
+                    String::from("KVM device node (/dev/kvm) should be accessible"),
                 )
             } else {
-                (TestResult::Ok, "")
+                (TestState::Ok, String::new())
             }
         }
         Err(_) => (
-            TestResult::Failed,
-            "Unable to read KVM device node file (/dev/kvm)",
+            TestState::Failed,
+            String::from("Unable to read KVM device node file (/dev/kvm)"),
         ),
-    };
-
-    report_results(
-        result,
-        "Check KVM is supported (required)",
-        reason,
-        TestOptionalState::Required,
-        None,
-    );
+    }
 }
 
-pub fn check_kvm_module_supported(param: KvmParameter) {
+pub fn check_kvm_module_supported(param: KvmParameter) -> (TestState, String, String) {
     let param_loc = match param {
         KvmParameter::Tdx => "/sys/module/kvm_intel/parameters/tdx",
         KvmParameter::Sgx => "/sys/module/kvm_intel/parameters/sgx",
@@ -330,10 +152,10 @@ pub fn check_kvm_module_supported(param: KvmParameter) {
         match std::fs::read_to_string(param_loc) {
             Ok(result) => {
                 if result.trim() == "1" || result.trim() == "Y" {
-                    (TestResult::Ok, String::new())
+                    (TestState::Ok, String::new())
                 } else {
                     (
-                        TestResult::Failed,
+                        TestState::Failed,
                         format!(
                             "Parameter file ({}) contains invalid value: {}",
                             param_loc, result
@@ -342,13 +164,13 @@ pub fn check_kvm_module_supported(param: KvmParameter) {
                 }
             }
             Err(e) => (
-                TestResult::Failed,
+                TestState::Failed,
                 format!("Unable to read parameter file: {}", e),
             ),
         }
     } else {
         (
-            TestResult::Failed,
+            TestState::Failed,
             format!("Provided parameter does not exist: {}", param_loc),
         )
     };
@@ -357,25 +179,25 @@ pub fn check_kvm_module_supported(param: KvmParameter) {
         "Check /sys/module/kvm_intel/parameters/{} = Y (required)",
         param_loc[param_loc.rfind('/').unwrap() + 1..].to_owned()
     );
-    report_results(result, &action, &reason, TestOptionalState::Required, None);
+
+    (result, action, reason)
 }
 
 fn report_results(
-    result: TestResult,
+    result: TestState,
     action: &str,
     reason: &str,
     optional: TestOptionalState,
-    operation: Option<TestOperation>,
+    operation: Option<TestOperationState>,
 ) {
-    use colored::Colorize;
     let mut reason = reason;
     let res = String::from(&result);
 
     match result {
-        TestResult::Ok => {
+        TestState::Ok => {
             println!("[ {} ] {}", res.green(), action);
         }
-        TestResult::Warning => {
+        TestState::Warning => {
             println!("[ {} ] {}", res.magenta(), action);
             if !reason.is_empty() {
                 println!("\tReason: {}", reason.yellow());
@@ -388,7 +210,7 @@ fn report_results(
             }
 
             if operation.is_some() {
-                if let TestOperation::Manual = operation.unwrap() {
+                if let TestOperationState::Manual = operation.unwrap() {
                     color = "yellow";
                     reason = "Unable to check in program. Please check manually.";
                 }
@@ -402,26 +224,440 @@ fn report_results(
     }
 }
 
-pub fn run_all_checks() {
+fn report_result(result: &mut TestResult) {
+    let state = String::from(&result.state);
+
+    match result.state {
+        TestState::Ok => {
+            println!("[ {} ] {}", state.green(), result.action);
+        }
+        TestState::Warning => {
+            println!("[ {} ] {}", state.magenta(), result.action);
+            if !result.reason.is_empty() {
+                println!("\tReason: {}", result.reason.yellow());
+            }
+        }
+        _ => {
+            let mut color: &str = "red";
+            if let TestOptionalState::Optional = result.optional_state {
+                color = "yellow";
+            }
+
+            if let TestState::Tbd = result.state {
+                color = "yellow";
+            }
+
+            if let TestOperationState::Manual = result.operation {
+                color = "yellow";
+
+                if let TestState::Failed = result.state {
+                    color = "red";
+                }
+
+                result.reason = String::from("Unable to check in program. Please check manually.");
+            }
+            println!("[ {} ] {}", state.color(color), result.action);
+            if !result.reason.is_empty() {
+                let reason_str = format!("\tReason: {}", result.reason).color(color);
+                println!("{}", reason_str);
+            }
+        }
+    }
+}
+
+pub fn run_all_checks() -> Result<()> {
     println!("Required Features & Settings");
     println!("============================");
-    check_os();
-    check_tdx_module();
-    check_bios_enabling_mktme();
-    check_bios_tme_mt();
-    check_bios_enabling_tdx();
-    check_bios_tdx_key_split();
-    check_bios_enabling_sgx();
-    check_bios_sgx_reg_server();
-    check_cpu_manufacturer_id();
-    check_kvm_supported();
-    check_kvm_module_supported(KvmParameter::Tdx);
-    check_kvm_module_supported(KvmParameter::Sgx);
+    let required_tests = get_required_tests();
+    let required_tests_passed = run_test(&required_tests);
 
     println!();
     println!("Optional Features & Settings");
     println!("============================");
-    check_bios_memory_map();
-    check_bios_tme_bypass();
-    check_bios_seam_loader();
+    let optional_tests = get_optional_tests();
+    let _ = run_test(&optional_tests);
+
+    if !required_tests_passed {
+        Err(anyhow!("One or more required tests failed"))
+    } else {
+        Ok(())
+    }
+}
+
+fn run_test(tests: &[Test]) -> bool {
+    let mut passed = true;
+
+    for t in tests {
+        let mut res = (t.run)();
+        report_result(&mut res);
+        if let Some(f) = &t.post_run {
+            (f)();
+        }
+        match res.state {
+            TestState::Ok => {
+                if !run_test(&t.sub_tests) {
+                    passed = false;
+                }
+            }
+            TestState::Failed => {
+                passed = false;
+                report_skip_result(&t.sub_tests);
+            }
+            TestState::Tbd => {}
+            TestState::Skip => {}
+            TestState::Warning => {}
+        }
+    }
+
+    passed
+}
+
+fn report_skip_result(tests: &[Test]) {
+    for t in tests {
+        let res = TestResult {
+            state: TestState::Skip,
+            action: t.name.to_string(),
+            ..Default::default()
+        };
+        let state = String::from(&res.state);
+        println!("[ {} ] {}", state.yellow(), res.action);
+        report_skip_result(&t.sub_tests);
+    }
+}
+
+fn get_optional_tests() -> Vec<Test> {
+    let bios_mem_map_test = Test {
+        name: "Volatile Memory should be 1LM",
+        run: Box::new(|| TestResult {
+            action: String::from("Check BIOS: Volatile Memory should be 1LM"),
+            state: TestState::Tbd,
+            optional_state: TestOptionalState::Optional,
+            operation: TestOperationState::Manual,
+            ..Default::default()
+        }),
+        sub_tests: vec![],
+        post_run: Some(Box::new(|| {
+            println!("\tPlease check your BIOS settings:");
+            println!("\t\tSocket Configuration -> Memory Configuration -> Memory Map");
+            println!("\t\t\tVolatile Memory (or Volatile Memory Mode) should be 1LM");
+            println!("\t\tA different BIOS might have a different path for this setting.");
+            println!("\t\tPlease skip this setting if it doesn't exist in your BIOS menu.");
+        })),
+    };
+
+    let bios_tme_bypass_test = Test {
+        name: "TME Bypass is enabled",
+        run: Box::new(|| {
+            let state = if check_bios_tme_bypass() {
+                TestState::Ok
+            } else {
+                TestState::Failed
+            };
+
+            TestResult {
+                action: String::from("Check BIOS: TME Bypass = Enabled"),
+                reason: String::from("The bit 31 of MSR 0x982 should be 1"),
+                state,
+                optional_state: TestOptionalState::Optional,
+                ..Default::default()
+            }
+        }),
+        sub_tests: vec![],
+        post_run: Some(Box::new(|| {
+            if !check_bios_tme_bypass() {
+                println!("\tThe TME Bypass has not been enabled now.");
+            }
+
+            println!(
+                "\tIt's better to enable TME Bypass for traditional non-confidential workloads."
+            );
+        })),
+    };
+
+    let bios_seam_loader_test = Test {
+        name: "SEAM Loader is enabled",
+        run: Box::new(|| TestResult {
+            action: String::from("Check BIOS: SEAM Loader = Enabled"),
+            state: TestState::Tbd,
+            operation: TestOperationState::Manual,
+            optional_state: TestOptionalState::Optional,
+            ..Default::default()
+        }),
+        sub_tests: vec![],
+        post_run: None,
+    };
+
+    vec![
+        bios_mem_map_test,
+        bios_tme_bypass_test,
+        bios_seam_loader_test,
+    ]
+}
+
+fn get_required_tests() -> Vec<Test> {
+    //                       CPU Manufacturer ID
+    //                                |
+    //                                |
+    //                          OS is supported
+    //                                |
+    //                                |
+    //                          SGX is enabled
+    //                                |
+    //                                |
+    //                          TDX is enabled
+    //                                |
+    //                                |
+    //      +-------------------------+-----------------------+
+    //      |             |           |          |            |
+    //    TDX Mod.       TME       TME-MT     TDX Key      SGX Reg.
+    //  Initialized    Enabled    Enabled    Split != 0    Server
+
+    let tdx_enabled_test = Test {
+        name: "Check TDX enabled",
+        run: Box::new(|| {
+            let msr_value = Msr::new(0x1401, 0).unwrap().read().unwrap();
+            let state = if msr_value & (1 << 11) > 0 {
+                TestState::Ok
+            } else {
+                TestState::Failed
+            };
+            TestResult {
+                action: String::from("Check BIOS: TDX = Enabled"),
+                reason: String::from("The bit 11 of MSR 0x1401 should be 1"),
+                state,
+                ..Default::default()
+            }
+        }),
+        sub_tests: vec![
+            Test {
+                name: "Check TDX module initialized",
+                run: Box::new(|| {
+                    let module_initialized = check_tdx_module();
+                    let state = if module_initialized {
+                        TestState::Ok
+                    } else {
+                        TestState::Failed
+                    };
+                    TestResult {
+                        action: String::from("Check TDX Module: The module is initialized"),
+                        reason: String::from("TDX module is required"),
+                        state,
+                        ..Default::default()
+                    }
+                }),
+                sub_tests: vec![],
+                post_run: None,
+            },
+            Test {
+                name: "Check TME enabled",
+                run: Box::new(|| {
+                    let msr_value = Msr::new(0x982, 0).unwrap().read().unwrap();
+                    let state = if msr_value & (1 << 1) > 0 {
+                        TestState::Ok
+                    } else {
+                        TestState::Failed
+                    };
+                    TestResult {
+                        action: String::from("Check BIOS: TME = Enabled"),
+                        reason: String::from("The bit 1 of MSR 0x982 should be 1."),
+                        state,
+                        ..Default::default()
+                    }
+                }),
+                sub_tests: vec![],
+                post_run: None,
+            },
+            Test {
+                name: "Check TME-MT/TME-MK enabled",
+                run: Box::new(|| {
+                    let msr_value = Msr::new(0x982, 0).unwrap().read().unwrap();
+                    let state = if msr_value & (1 << 1) > 0 {
+                        TestState::Tbd
+                    } else {
+                        TestState::Failed
+                    };
+                    TestResult {
+                        action: String::from("Check BIOS: TME-MT/TME-MK = Enabled"),
+                        reason: String::from("The bit 1 of MSR 0x982 should be 1."),
+                        state,
+                        operation: TestOperationState::Manual,
+                        ..Default::default()
+                    }
+                }),
+                sub_tests: vec![],
+                post_run: Some(Box::new(|| {
+                    println!("\tPlease check your BIOS settings:");
+                    println!(
+                        "\t\tSocket Configuration -> Processor Configuration -> TME, TME-MT, TDX"
+                    );
+                    println!(
+                        "\t\t\tTotal Memory Encryption Multi-Tenant (TME-MT) should be Enable"
+                    );
+                    println!("\t\tA different BIOS might have a different path for this setting.");
+                })),
+            },
+            Test {
+                name: "Check TDX Key Split != 0",
+                run: Box::new(|| {
+                    let msr_value = Msr::new(0x981, 0).unwrap().read().unwrap();
+                    let state = if msr_value & (0x7fff << 36) != 0 {
+                        TestState::Ok
+                    } else {
+                        TestState::Failed
+                    };
+                    TestResult {
+                        action: String::from("Check BIOS: TDX Key Split != 0"),
+                        reason: String::from("TDX Key Split should be non-zero"),
+                        state,
+                        ..Default::default()
+                    }
+                }),
+                sub_tests: vec![],
+                post_run: None,
+            },
+            Test {
+                name: "Check SGX registration server",
+                run: Box::new(|| TestResult {
+                    action: String::from("Check BIOS: SGX registration server"),
+                    reason: String::from(""),
+                    state: TestState::Tbd,
+                    operation: TestOperationState::Manual,
+                    ..Default::default()
+                }),
+                sub_tests: vec![],
+                post_run: Some(Box::new(|| {
+                    let msr_value = Msr::new(0xce, 0).unwrap().read().unwrap();
+                    if msr_value & (1 << 27) > 0 {
+                        println!("\tSGX registration server is SBX");
+                    } else {
+                        println!("\tSGX registration server is LIV");
+                    }
+                })),
+            },
+        ],
+        post_run: None,
+    };
+
+    let sgx_enabled_test = Test {
+        name: "Check SGX enabled",
+        run: Box::new(|| {
+            let msr_value = Msr::new(0x3a, 0).unwrap().read().unwrap();
+            let state = if msr_value & (1 << 18) > 0 {
+                TestState::Ok
+            } else {
+                TestState::Failed
+            };
+            TestResult {
+                action: String::from("Check BIOS: SGX = Enabled"),
+                reason: String::from("The bit 18 of MSR 0x3a should be 1"),
+                state,
+                ..Default::default()
+            }
+        }),
+        sub_tests: vec![tdx_enabled_test],
+        post_run: None,
+    };
+
+    let os_distro_test = Test {
+        name: "Check OS distro",
+        run: Box::new(|| {
+            let supported = check_os();
+            let state = if supported {
+                TestState::Ok
+            } else {
+                TestState::Failed
+            };
+            TestResult {
+                action: String::from("Check OS: The distro and version are correct"),
+                reason: String::from("Your OS distro is not supported yet."),
+                state,
+                ..Default::default()
+            }
+        }),
+        sub_tests: vec![sgx_enabled_test],
+        post_run: Some(Box::new(|| {
+            let pretty_name = get_os_pretty_name();
+            println!("\tYour current OS is: {}", pretty_name);
+            println!("\tThe following OSs are supported:");
+            for os in SUPPORTED_OSES {
+                println!("\t\t{}", os);
+            }
+            println!("\tThere is no guarantee to other OS distros");
+        })),
+    };
+
+    let cpu_manu_id_test = Test {
+        name: "Check CPU Manufacturer ID",
+        run: Box::new(|| {
+            let manu_name = check_cpu_manufacturer_id();
+            let state = if manu_name == "GenuineIntel" {
+                TestState::Ok
+            } else {
+                TestState::Failed
+            };
+            TestResult {
+                action: String::from("Check CPUID 0x0 Manufacturer ID = GenuineIntel"),
+                reason: String::from("The CPUID Manufacturer ID should be GenuineIntel"),
+                state,
+                ..Default::default()
+            }
+        }),
+        sub_tests: vec![os_distro_test],
+        post_run: None,
+    };
+
+    //            KVM is enabled
+    //                  |
+    //                  |
+    //      +----------------------+
+    //      |                      |
+    //     SGX                    TDX
+    //  Mod Enabled           Mod Enabled
+
+    let kvm_sgx_mod_test = Test {
+        name: "Check KVM SGX parameter enabled",
+        run: Box::new(|| {
+            let (state, action, reason) = check_kvm_module_supported(KvmParameter::Sgx);
+            TestResult {
+                action,
+                reason,
+                state,
+                ..Default::default()
+            }
+        }),
+        sub_tests: vec![],
+        post_run: None,
+    };
+
+    let kvm_tdx_mod_test = Test {
+        name: "Check KVM TDX parameter enabled",
+        run: Box::new(|| {
+            let (state, action, reason) = check_kvm_module_supported(KvmParameter::Tdx);
+            TestResult {
+                action,
+                reason,
+                state,
+                ..Default::default()
+            }
+        }),
+        sub_tests: vec![],
+        post_run: None,
+    };
+
+    let kvm_supported_test = Test {
+        name: "Check KVM is supported",
+        run: Box::new(|| {
+            let (state, reason) = check_kvm_supported();
+            TestResult {
+                action: String::from("Check KVM is supported"),
+                reason,
+                state,
+                ..Default::default()
+            }
+        }),
+        sub_tests: vec![kvm_sgx_mod_test, kvm_tdx_mod_test],
+        post_run: None,
+    };
+
+    vec![cpu_manu_id_test, kvm_supported_test]
 }


### PR DESCRIPTION
Converts the current way of running the `ok` command checks into a tree-like structure. The checks are structured such that if a test fails, its dependents (tests that required its parent to pass) will be skipped and be marked as such.